### PR TITLE
Update Docksal install instructions link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Features:
 
 **This is a one time setup - skip this if you already have a working Docksal environment.**  
 
-Follow [Docksal environment setup instructions](http://docksal.readthedocs.io/en/master/getting-started/env-setup)
+Follow [Docksal install instructions](https://docs.docksal.io/getting-started/setup/)
 
 ### Step #2: Project setup
 


### PR DESCRIPTION
The existing link to Docksal instructions is broken. I think the new link is the correct place for it to point.