### PR TITLE
Adds KANOPI.md project description file

### DIFF
--- a/KANOPI.md
+++ b/KANOPI.md
@@ -1,0 +1,37 @@
+# Kanopi Studios Project
+
+This document is used to describe the development and continuous maintenance and
+ improvement of this project.
+
+## About the Project
+Use this space to describe the project, timeline, and client.
+
+## Team
+Add Kanopi and Client names and roles.
+
+## Important Links
+[Github](link_url)
+[Google Drive](link_url)
+[Sketch Cloud](link_url)
+[Teamwork](link_url)
+[UXPin](link_url)
+[Zeplin](link_url)
+[etc](link_url)
+
+## Development Notes
+Add notes as you go.  Which modules did you choose and why?  Did you try
+anything that failed?  Write ongoing stories about the project/releases here.
+
+## Documentation
+Describe how we're documenting this project.  In some cases, the answer is "all
+in code/annotations and nothing else".  In others it's a full
+[MkDocs](https://www.mkdocs.org/) instance with user stories that are constantly
+ updated throughout the life of the project.
+
+## Acronyms
+TMI - Too Much Information
+
+## Things We Learned Together
+Inside jokes and other fun memes bring teams together when working on projects,
+but can feel exclusionary to new team members.  List your jokes and personable
+notes here to help bring your new team members up to speed.


### PR DESCRIPTION
This PR adds an additional readme style document to the base repository to help add additional documentation to the project to help onboard new developers, pass off to support at the end of the build, and write case studies after the project launches.

This doc defines the development of the project, not just the code as a traditional readme file does.

If merged, this PR would close #9 